### PR TITLE
Two fixups for buildslave packages

### DIFF
--- a/buildslave/bootstrap.sh
+++ b/buildslave/bootstrap.sh
@@ -15,6 +15,7 @@ apt-get install -y pkg-config
 apt-get install -y libpam0g-dev
 apt-get install -y ntp
 apt-get install -y dpkg-dev debhelper fakeroot
+apt-get install -y libexpat1-dev
 
 # Remove unneeded packages and cache:
 # for some reason libltdl7 must not be installed so let's make sure it really isn't


### PR DESCRIPTION
Turns out some packages must not be installed on buildslave VMs and some that are required may potentially be missing. See commit messages for details.