### PR TITLE
Updated cf-builder for Ubuntu 20 / new gcc 

### DIFF
--- a/cf-builder.py
+++ b/cf-builder.py
@@ -46,8 +46,8 @@ def perform_step(step, repo, source, warnings, build_folder=None):
 
     autogen = "./autogen.sh -C --enable-debug" + (
         " --with-postgresql-hub=/usr" if repo == "nova" else "")
-    make = "make -j2" + (
-        " CFLAGS='-Werror -Wall -Wno-pointer-sign' LDFLAGS='-pthread'"
+    make = "make -j8" + (
+        " CFLAGS='-Werror -Wall -Wno-pointer-sign -Wno-format-truncation -Wno-format-overflow'"
         if warnings else "")
     command_dict = {
         "checkout": "git checkout {}".format(optarg),

--- a/repos/clone.sh
+++ b/repos/clone.sh
@@ -6,6 +6,7 @@ cloner(){
     else
         git clone --recursive --origin upstream git@github.com:$1/$2.git && \
         cd $2 && \
+        git remote add origin git@github.com:$(whoami)/$2.git && \
         git fetch --all --tags && \
         cd ..
     fi


### PR DESCRIPTION
Updated my WSL to use Ubuntu 20.04.

Had to add some more warning exceptions (which we should fix),
because of new version of gcc.

Also removed the LDFLAGS which is no longer needed (CFLAGS was
handled incorrectly before).

Job count for make increased to 8, gotta go fast.