### PR TITLE
cf-builder.py: Use --load argument to make

### DIFF
--- a/cf-builder.py
+++ b/cf-builder.py
@@ -46,7 +46,7 @@ def perform_step(step, repo, source, warnings, build_folder=None):
 
     autogen = "./autogen.sh -C --enable-debug" + (
         " --with-postgresql-hub=/usr" if repo == "nova" else "")
-    make = "make -j8" + (
+    make = "make -j -l8" + (
         " CFLAGS='-Werror -Wall -Wno-pointer-sign -Wno-format-truncation -Wno-format-overflow'"
         if warnings else "")
     command_dict = {


### PR DESCRIPTION
Should allow make to use fewer than 8 jobs when load is high,
and more than 8 when load is low.