### PR TITLE
cf-builder.py: Removed 1 C compiler warning exception

### DIFF
--- a/cf-builder.py
+++ b/cf-builder.py
@@ -47,7 +47,7 @@ def perform_step(step, repo, source, warnings, build_folder=None):
     autogen = "./autogen.sh -C --enable-debug" + (
         " --with-postgresql-hub=/usr" if repo == "nova" else "")
     make = "make -j -l8" + (
-        " CFLAGS='-Werror -Wall -Wno-pointer-sign -Wno-format-truncation -Wno-format-overflow'"
+        " CFLAGS='-Werror -Wall -Wno-pointer-sign -Wno-format-truncation'"
         if warnings else "")
     command_dict = {
         "checkout": "git checkout {}".format(optarg),


### PR DESCRIPTION
No longer needed after:
https://github.com/cfengine/core/pull/4297