### PR TITLE
cf-builder.py: Removed -Wno-pointer-sign flag

### DIFF
--- a/cf-builder.py
+++ b/cf-builder.py
@@ -47,7 +47,7 @@ def perform_step(step, repo, source, warnings, build_folder=None):
     autogen = "./autogen.sh -C --enable-debug" + (
         " --with-postgresql-hub=/usr" if repo == "nova" else "")
     make = "make -j -l8" + (
-        " CFLAGS='-Werror -Wall -Wno-pointer-sign -Wno-format-truncation'"
+        " CFLAGS='-Werror -Wall -Wno-format-truncation'"
         if warnings else "")
     command_dict = {
         "checkout": "git checkout {}".format(optarg),


### PR DESCRIPTION
No longer needed after these PRs:
https://github.com/cfengine/core/pull/4298
https://github.com/cfengine/nova/pull/1708