### PR TITLE
CFE-3409 cf-builder.py: Removed -Wno-format-truncation flag

### DIFF
--- a/cf-builder.py
+++ b/cf-builder.py
@@ -47,7 +47,7 @@ def perform_step(step, repo, source, warnings, build_folder=None):
     autogen = "./autogen.sh -C --enable-debug" + (
         " --with-postgresql-hub=/usr" if repo == "nova" else "")
     make = "make -j -l8" + (
-        " CFLAGS='-Werror -Wall -Wno-format-truncation'"
+        " CFLAGS='-Werror -Wall'"
         if warnings else "")
     command_dict = {
         "checkout": "git checkout {}".format(optarg),


### PR DESCRIPTION
No longer needed after these PRs:
https://github.com/cfengine/core/pull/4308
https://github.com/cfengine/enterprise/pull/631
https://github.com/cfengine/nova/pull/1710