### PR TITLE
Now syncs clock between host and guests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Install guest additions plugin:
 $ vagrant plugin install vagrant-vbguest
 ```
 
+**Optional:** Install timezone plugin to avoid clock-skew when using tools like
+Make and rsync on shared files.
+```
+$ vagrant plugin install vagrant-timezone
+```
+
 It is also possible to use libvirt (KVM) instead of VirtualBox. Apart from the
 working `qemu-kvm` setup and `libvirt`, the `vagrant-libvirt` plugin has to be
 installed too. It may either be provided as a package in your distribution or it

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,6 +41,12 @@ Vagrant.configure("2") do |config|
         vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
     end
 
+    # Synchonize clock with host OS to avoid clock skew when using tools like
+    # Make and rsync. Only do this if "vagrant-timezone" plugin is installed.
+    if Vagrant.has_plugin?("vagrant-timezone")
+        config.timezone.value = :host
+    end
+
     # https://bugs.launchpad.net/cloud-images/+bug/1874453
     NOW = Time.now.strftime("%d.%m.%Y.%H:%M:%S")
     FILENAME = "serial-debug-%s.log" % NOW


### PR DESCRIPTION
Now uses `vagrant-timezone` plugin (if installed) to synchronise clock
between host and guests. This way we avoid clock skew when using tools
like Make and rsync on files shared with host.
